### PR TITLE
Take advantage of knowing what pins you picked.

### DIFF
--- a/Adafruit_LiquidCrystal.cpp
+++ b/Adafruit_LiquidCrystal.cpp
@@ -416,10 +416,7 @@ void Adafruit_LiquidCrystal::write4bits(uint8_t value) {
 
 
     // speed up for i2c since its sluggish
-    for (int i = 0; i < 4; i++) {
-      out &= ~_BV(_data_pins[i]);
-      out |= ((value >> i) & 0x1) << _data_pins[i];
-    }
+    out = (out & ~0x78) | ((value & 0x0F) << 3);
 
     // make sure enable is low
     out &= ~ _BV(_enable_pin);


### PR DESCRIPTION
Since the i2c code has hardcoded values for _data_pins[x],
which are set to fixed values in the only case where _i2caddr
isn't 255, why not just take advantage of the fact that we
want to put four consecutive bits in four consecutive bits,
and we know which bits in advance?

No idea of performance impact, and instructions are pretty
cheap, but this removes a lot of shifts which necessarily have
to be done at runtime (because the compiler can't tell that
these values are actually fixed), plus some looping and array
indexing.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
